### PR TITLE
temp-colcon-cache-branch-5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,17 @@ _commands:
       steps:
         - restore_cache:
             name: Restore Cache << parameters.key >>
-            key: "<< parameters.key >>-v1\
-              -{{ arch }}\
-              -{{ .Branch }}\
-              -{{ .Environment.CIRCLE_PR_NUMBER }}\
-              -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
+            keys:
+              - "<< parameters.key >>-v1\
+                -{{ arch }}\
+                -{{ .Branch }}\
+                -{{ .Environment.CIRCLE_PR_NUMBER }}\
+                -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
+              - "<< parameters.key >>-v1\
+                -{{ arch }}\
+                -main\
+                -<no value>\
+                -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
     save_to_cache:
       description: "Save To Cache"
       parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,16 @@ _commands:
                   command: |
                     colcon cache lock
 
-                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xargs)
-                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xargs)
+                    BUILD_UNFINISHED=$(
+                      colcon list \
+                        --names-only \
+                        --packages-skip-build-finished \
+                      | xargs)
+                    BUILD_FAILED=$(
+                      colcon list \
+                        --names-only \
+                        --packages-select-build-failed \
+                      | xargs)
 
                     . << parameters.underlay >>/install/setup.sh
                     rm -rf log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,17 +120,19 @@ _commands:
                   name: Build Workspace | << parameters.workspace >>
                   working_directory: << parameters.workspace >>
                   command: |
-                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished)
-                    BUILD_FAILED=$(colcon list --packages-select-build-failed)
-                    if [ -n "$BUILD_UNFINISHED" ] || [ -n "$BUILD_FAILED" ]
-                    then
-                      . << parameters.underlay >>/install/setup.sh
-                      rm -rf build install log
-                      colcon build \
-                        --mixin << parameters.mixins >>
-                    else
-                      echo "Skipping Build"
-                    fi
+                    colcon cache lock
+
+                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xarg)
+                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xarg)
+
+                    . << parameters.underlay >>/install/setup.sh
+                    rm -rf log
+                    colcon build \
+                      --packages-above \
+                        $BUILD_UNFINISHED \
+                        $BUILD_FAILED \
+                      --packages-skip-cache-hit \
+                      --mixin << parameters.mixins >>
               - save_to_cache:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
@@ -154,12 +156,14 @@ _commands:
             command: |
               . install/setup.sh
               TEST_PACKAGES=$(
-                colcon list --names-only | \
-                  circleci tests split \
-                    --split-by=timings \
-                    --timings-type=classname \
-                    --show-counts | \
-                  xargs)
+                colcon list \
+                  --names-only \
+                  --packages-skip-cache-hit \
+                | circleci tests split \
+                  --split-by=timings \
+                  --timings-type=classname \
+                  --show-counts \
+                | xargs)
               set -o xtrace
               colcon test \
                 --packages-select ${TEST_PACKAGES} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,12 @@ _commands:
                         --names-only \
                         --packages-select-build-failed \
                       | xargs)
+                    BUILD_VOID=$(
+                      colcon list \
+                        --names-only \
+                        --packages-select-cache-void \
+                        --packages-respective-cache-verb build \
+                      | xargs)
 
                     . << parameters.underlay >>/install/setup.sh
                     rm -rf log
@@ -140,7 +146,7 @@ _commands:
                       --packages-above \
                         $BUILD_UNFINISHED \
                         $BUILD_FAILED \
-                      --packages-skip-cache-hit \
+                        $BUILD_VOID \
                       --mixin << parameters.mixins >>
               - save_to_cache:
                   key: << parameters.key >>
@@ -168,11 +174,25 @@ _commands:
             name: Test Workspace | << parameters.workspace >>
             working_directory: << parameters.workspace >>
             command: |
+              TEST_FAILURES=$(
+                colcon list \
+                  --names-only \
+                  --packages-select-test-failures \
+                | xargs)
+              TEST_VOID=$(
+                colcon list \
+                  --names-only \
+                  --packages-select-cache-void \
+                  --packages-respective-cache-verb test \
+                | xargs)
+
               . install/setup.sh
               TEST_PACKAGES=$(
                 colcon list \
                   --names-only \
-                  --packages-skip-cache-hit \
+                  --packages-above \
+                    $TEST_FAILURES \
+                    $TEST_VOID \
                 | circleci tests split \
                   --split-by=timings \
                   --timings-type=classname \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,8 @@ _commands:
                   command: |
                     colcon cache lock
 
-                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xarg)
-                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xarg)
+                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xargs)
+                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xargs)
 
                     . << parameters.underlay >>/install/setup.sh
                     rm -rf log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ _commands:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
                   workspace: << parameters.workspace >>
+                  when: always
               - run:
                   name: Copy Build Logs
                   working_directory: << parameters.workspace >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,6 @@ _commands:
             command: |
               . << parameters.underlay >>/install/setup.sh
               cat << parameters.underlay >>/checksum.txt > checksum.txt
-              vcs export --exact src | \
-                (echo vcs_export && cat) >> checksum.txt
-              sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
               rosdep update
 
@@ -145,6 +142,13 @@ _commands:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
                   workspace: << parameters.workspace >>
+              - run:
+                  name: Append Checksum | << parameters.workspace >>
+                  working_directory: << parameters.workspace >>
+                  command: |
+                    vcs export --exact src | \
+                      (echo vcs_export && cat) >> checksum.txt
+                    sha256sum $PWD/checksum.txt >> checksum.txt
               - run:
                   name: Copy Build Logs
                   working_directory: << parameters.workspace >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ _commands:
               -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}\
               -{{ epoch }}"
             paths:
-              - << parameters.path >>
+              - << parameters.path >>/build
+              - << parameters.path >>/install
             when: << parameters.when >>
     install_dependencies:
       description: "Install Dependencies"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ _environments:
 executors:
   debug_exec:
     docker:
-      - image: rosplanning/navigation2:main.debug
+      - image: ruffsl/navigation2:main.debug
     working_directory: /opt/overlay_ws
     environment:
       <<: *common_environment
@@ -381,7 +381,7 @@ executors:
       UNDERLAY_MIXINS: "release ccache"
   release_exec:
     docker:
-      - image: rosplanning/navigation2:main.release
+      - image: ruffsl/navigation2:main.release
     working_directory: /opt/overlay_ws
     environment:
       <<: *common_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,20 +434,20 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - debug_build
-      - debug_test:
-          requires:
-            - debug_build
+      # - debug_build
+      # - debug_test:
+      #     requires:
+      #       - debug_build
       - release_build
       - release_test:
           requires:
             - release_build
   nightly:
     jobs:
-      - debug_build
-      - debug_test:
-          requires:
-            - debug_build
+      # - debug_build
+      # - debug_test:
+      #     requires:
+      #       - debug_build
       - release_build
       - release_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ _commands:
             command: |
               . << parameters.underlay >>/install/setup.sh
               cat << parameters.underlay >>/checksum.txt > checksum.txt
+              vcs export --exact << parameters.underlay >>/src | \
+                (echo vcs_export && cat) >> checksum.txt
+              sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
               rosdep update
 
@@ -143,13 +146,6 @@ _commands:
                   path: << parameters.workspace >>
                   workspace: << parameters.workspace >>
               - run:
-                  name: Append Checksum | << parameters.workspace >>
-                  working_directory: << parameters.workspace >>
-                  command: |
-                    vcs export --exact src | \
-                      (echo vcs_export && cat) >> checksum.txt
-                    sha256sum $PWD/checksum.txt >> checksum.txt
-              - run:
                   name: Copy Build Logs
                   working_directory: << parameters.workspace >>
                   command: cp -rH log/latest_build log/build
@@ -218,7 +214,7 @@ _steps:
     run:
       name: Pre Checkout
       command: |
-        mkdir -p $ROS_WS && cd $ROS_WS
+        mkdir -p $ROS_WS/src && cd $ROS_WS
         ln -s /opt/ros/$ROS_DISTRO install
         echo $CACHE_NONCE | \
           (echo cache_nonce && cat) >> checksum.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ _commands:
               sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
               rosdep update
-              
+
               # workarround for OMPL and rosdep
               # https://github.com/ompl/ompl/issues/753
               # Prevent searching $ROS_WS/install given it's too big for rosdep
@@ -465,13 +465,13 @@ workflows:
             branches:
               only:
                 - main
-  dockerhub:
-    jobs:
-      - rebuild_dockerhub
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - main
+  # dockerhub:
+  #   jobs:
+  #     - rebuild_dockerhub
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 7 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,8 +455,8 @@ workflows:
           matrix:
             parameters:
               rmw:
-                - rmw_connextdds
-                - rmw_cyclonedds_cpp
+                # - rmw_connextdds
+                # - rmw_cyclonedds_cpp
                 - rmw_fastrtps_cpp
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,8 +157,12 @@ _commands:
     test_workspace:
       description: "Test Workspace"
       parameters:
+        key:
+          type: string
         workspace:
           type: string
+        cache_test:
+          type: boolean
       steps:
         - run:
             name: Test Workspace | << parameters.workspace >>
@@ -181,6 +185,14 @@ _commands:
                 --ctest-args --test-regex "test_.*"
               colcon test-result \
                 --verbose
+        - when:
+            condition: << parameters.cache_test >>
+            steps:
+              - save_to_cache:
+                  key: << parameters.key >>
+                  path: << parameters.workspace >>
+                  workspace: << parameters.workspace >>
+                  when: always
         - run:
             name: Copy Test Logs
             working_directory: << parameters.workspace >>
@@ -297,7 +309,9 @@ _steps:
       when: always
   test_overlay_workspace: &test_overlay_workspace
     test_workspace:
+      key: overlay_ws
       workspace: /opt/overlay_ws
+      cache_test: << parameters.cache_test >>
   collect_overlay_coverage: &collect_overlay_coverage
     run:
       name: Collect Code Coverage
@@ -362,6 +376,9 @@ commands:
       - *restore_overlay_workspace
   test_build:
     description: "Test Build"
+    parameters:
+      cache_test:
+        type: boolean
     steps:
       - *test_overlay_workspace
   report_coverage:
@@ -415,6 +432,9 @@ executors:
 _jobs:
   job_test: &job_test
     parameters:
+      cache_test:
+        type: boolean
+        default: false
       rmw:
         default: "rmw_cyclonedds_cpp"
         type: string
@@ -437,14 +457,16 @@ jobs:
     executor: debug_exec
     steps:
       - restore_build
-      - test_build
+      - test_build:
+          cache_test: << parameters.cache_test >>
       - report_coverage
   release_test:
     <<: *job_test
     executor: release_exec
     steps:
       - restore_build
-      - test_build
+      - test_build:
+          cache_test: << parameters.cache_test >>
   rebuild_dockerhub:
     executor: python_exec
     steps:
@@ -458,10 +480,13 @@ workflows:
       # - debug_test:
       #     requires:
       #       - debug_build
+      #     parameters:
+      #       cache_test: true
       - release_build
-      # - release_test:
-      #     requires:
-      #       - release_build
+      - release_test:
+          requires:
+            - release_build
+          cache_test: true
   nightly:
     jobs:
       # - debug_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,9 +461,9 @@ workflows:
       #     requires:
       #       - debug_build
       - release_build
-      - release_test:
-          requires:
-            - release_build
+      # - release_test:
+      #     requires:
+      #       - release_build
   nightly:
     jobs:
       # - debug_build
@@ -471,15 +471,15 @@ workflows:
       #     requires:
       #       - debug_build
       - release_build
-      - release_test:
-          requires:
-            - release_build
-          matrix:
-            parameters:
-              rmw:
-                # - rmw_connextdds
-                # - rmw_cyclonedds_cpp
-                - rmw_fastrtps_cpp
+      # - release_test:
+      #     requires:
+      #       - release_build
+      #     matrix:
+      #       parameters:
+      #         rmw:
+      #           # - rmw_connextdds
+      #           # - rmw_cyclonedds_cpp
+      #           - rmw_fastrtps_cpp
     triggers:
       - schedule:
           cron: "0 13 * * *"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ FROM $FROM_IMAGE AS cacher
 ARG UNDERLAY_WS
 WORKDIR $UNDERLAY_WS/src
 COPY ./tools/underlay.repos ../
-RUN vcs import ./ < ../underlay.repos && \
-    find ./ -name ".git" | xargs rm -rf
+RUN vcs import ./ < ../underlay.repos
 
 # copy overlay source
 ARG OVERLAY_WS

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN . $UNDERLAY_WS/install/setup.sh && \
 
 # install CI dependencies
 RUN pip3 install \
-      git+https://github.com/ruffsl/colcon-cache.git
+      git+https://github.com/ruffsl/colcon-cache.git@c8d4b3b84c67e8897731906aa11cd9e8911f5674
 
 # source overlay from entrypoint
 ENV UNDERLAY_WS $UNDERLAY_WS

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,10 @@ RUN . $UNDERLAY_WS/install/setup.sh && \
       --mixin $OVERLAY_MIXINS \
     || ([ -z "$FAIL_ON_BUILD_FAILURE" ] || exit 1)
 
+# install CI dependencies
+RUN pip3 install \
+      git+https://github.com/ruffsl/colcon-cache.git
+
 # source overlay from entrypoint
 ENV UNDERLAY_WS $UNDERLAY_WS
 ENV OVERLAY_WS $OVERLAY_WS

--- a/nav2_bringup/nav2_gazebo_spawner/nav2_gazebo_spawner/nav2_gazebo_spawner.py
+++ b/nav2_bringup/nav2_gazebo_spawner/nav2_gazebo_spawner/nav2_gazebo_spawner.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019 Intel Corporation
+# temp-colcon-cache-branch-5
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Oh yea, check this out. I've got colcon-cache working to help cache the build and test verbs. This sample PR only modifies the `nav2_gazebo_spawner` package, that doesn't have any other packages that depend upon it, so when restoring the cache and falling back to the cache provided from the main branch, the CI will only attempt to rebuild and retest packages that have changed (or still haven't yet passed at building and testing from before).

CI job from main branch (29m 0s):
* https://app.circleci.com/pipelines/github/ruffsl/navigation2/934/workflows/fb8b3de5-44c1-4822-9ecf-355d0a1e7729

CI job for this PR branch (5m 39s):
* https://app.circleci.com/pipelines/github/ruffsl/navigation2/935/workflows/14ea80d4-5c44-4c8b-b997-45ef5aecdf6e

## Build Workspace | /opt/overlay_ws 5s

<details>

```
#!/bin/bash -eo pipefail
colcon cache lock

BUILD_UNFINISHED=$(
  colcon list \
    --names-only \
    --packages-skip-build-finished \
  | xargs)
BUILD_FAILED=$(
  colcon list \
    --names-only \
    --packages-select-build-failed \
  | xargs)
BUILD_VOID=$(
  colcon list \
    --names-only \
    --packages-select-cache-void \
    --packages-respective-cache-verb build \
  | xargs)

. /opt/underlay_ws/install/setup.sh
rm -rf log
colcon build \
  --packages-above \
    $BUILD_UNFINISHED \
    $BUILD_FAILED \
    $BUILD_VOID \
  --mixin ${OVERLAY_MIXINS}

Starting >>> nav2_common
]0;colcon cache [0/31 done] [1 ongoing]Finished <<< nav2_common [0.01s]
]0;colcon cache [1/31 done] [0 ongoing]Starting >>> nav_2d_msgs
]0;colcon cache [1/31 done] [1 ongoing]Finished <<< nav_2d_msgs [0.01s]
]0;colcon cache [2/31 done] [0 ongoing]Starting >>> nav2_gazebo_spawner
]0;colcon cache [2/31 done] [1 ongoing]Finished <<< nav2_gazebo_spawner [0.01s]
]0;colcon cache [3/31 done] [0 ongoing]Starting >>> nav2_msgs
]0;colcon cache [3/31 done] [1 ongoing]Finished <<< nav2_msgs [0.01s]
]0;colcon cache [4/31 done] [0 ongoing]Starting >>> nav2_voxel_grid
]0;colcon cache [4/31 done] [1 ongoing]Finished <<< nav2_voxel_grid [0.03s]
]0;colcon cache [5/31 done] [0 ongoing]Starting >>> dwb_msgs
]0;colcon cache [5/31 done] [1 ongoing]Finished <<< dwb_msgs [0.02s]
]0;colcon cache [6/31 done] [0 ongoing]Starting >>> nav2_util
]0;colcon cache [6/31 done] [1 ongoing]Finished <<< nav2_util [0.01s]
]0;colcon cache [7/31 done] [0 ongoing]Starting >>> nav_2d_utils
]0;colcon cache [7/31 done] [1 ongoing]Finished <<< nav_2d_utils [0.02s]
]0;colcon cache [8/31 done] [0 ongoing]Starting >>> nav2_behavior_tree
]0;colcon cache [8/31 done] [1 ongoing]Finished <<< nav2_behavior_tree [0.02s]
]0;colcon cache [9/31 done] [0 ongoing]Starting >>> nav2_lifecycle_manager
]0;colcon cache [9/31 done] [1 ongoing]Finished <<< nav2_lifecycle_manager [0.02s]
]0;colcon cache [10/31 done] [0 ongoing]Starting >>> nav2_map_server
]0;colcon cache [10/31 done] [1 ongoing]Finished <<< nav2_map_server [0.02s]
]0;colcon cache [11/31 done] [0 ongoing]Starting >>> nav2_amcl
]0;colcon cache [11/31 done] [1 ongoing]Finished <<< nav2_amcl [0.01s]
]0;colcon cache [12/31 done] [0 ongoing]Starting >>> nav2_costmap_2d
]0;colcon cache [12/31 done] [1 ongoing]Finished <<< nav2_costmap_2d [0.02s]
]0;colcon cache [13/31 done] [0 ongoing]Starting >>> nav2_rviz_plugins
]0;colcon cache [13/31 done] [1 ongoing]Finished <<< nav2_rviz_plugins [0.02s]
]0;colcon cache [14/31 done] [0 ongoing]Starting >>> nav2_core
]0;colcon cache [14/31 done] [1 ongoing]Finished <<< nav2_core [0.01s]
]0;colcon cache [15/31 done] [0 ongoing]Starting >>> costmap_queue
]0;colcon cache [15/31 done] [1 ongoing]Finished <<< costmap_queue [0.02s]
]0;colcon cache [16/31 done] [0 ongoing]Starting >>> dwb_core
]0;colcon cache [16/31 done] [1 ongoing]Finished <<< dwb_core [0.02s]
]0;colcon cache [17/31 done] [0 ongoing]Starting >>> nav2_bt_navigator
]0;colcon cache [17/31 done] [1 ongoing]Finished <<< nav2_bt_navigator [0.04s]
]0;colcon cache [18/31 done] [0 ongoing]Starting >>> nav2_controller
]0;colcon cache [18/31 done] [1 ongoing]Finished <<< nav2_controller [0.03s]
]0;colcon cache [19/31 done] [0 ongoing]Starting >>> nav2_navfn_planner
]0;colcon cache [19/31 done] [1 ongoing]Finished <<< nav2_navfn_planner [0.02s]
]0;colcon cache [20/31 done] [0 ongoing]Starting >>> nav2_planner
]0;colcon cache [20/31 done] [1 ongoing]Finished <<< nav2_planner [0.02s]
]0;colcon cache [21/31 done] [0 ongoing]Starting >>> nav2_recoveries
]0;colcon cache [21/31 done] [1 ongoing]Finished <<< nav2_recoveries [0.04s]
]0;colcon cache [22/31 done] [0 ongoing]Starting >>> nav2_regulated_pure_pursuit_controller
]0;colcon cache [22/31 done] [1 ongoing]Finished <<< nav2_regulated_pure_pursuit_controller [0.02s]
]0;colcon cache [23/31 done] [0 ongoing]Starting >>> nav2_smac_planner
]0;colcon cache [23/31 done] [1 ongoing]Finished <<< nav2_smac_planner [0.02s]
]0;colcon cache [24/31 done] [0 ongoing]Starting >>> nav2_waypoint_follower
]0;colcon cache [24/31 done] [1 ongoing]Finished <<< nav2_waypoint_follower [0.04s]
]0;colcon cache [25/31 done] [0 ongoing]Starting >>> dwb_critics
]0;colcon cache [25/31 done] [1 ongoing]Finished <<< dwb_critics [0.03s]
]0;colcon cache [26/31 done] [0 ongoing]Starting >>> dwb_plugins
]0;colcon cache [26/31 done] [1 ongoing]Finished <<< dwb_plugins [0.02s]
]0;colcon cache [27/31 done] [0 ongoing]Starting >>> nav2_dwb_controller
]0;colcon cache [27/31 done] [1 ongoing]Finished <<< nav2_dwb_controller [0.05s]
]0;colcon cache [28/31 done] [0 ongoing]Starting >>> navigation2
]0;colcon cache [28/31 done] [1 ongoing]Finished <<< navigation2 [0.05s]
]0;colcon cache [29/31 done] [0 ongoing]Starting >>> nav2_bringup
]0;colcon cache [29/31 done] [1 ongoing]Finished <<< nav2_bringup [0.08s]
]0;colcon cache [30/31 done] [0 ongoing]Starting >>> nav2_system_tests
]0;colcon cache [30/31 done] [1 ongoing]Finished <<< nav2_system_tests [0.31s]
]0;colcon cache [31/31 done] [0 ongoing]
Summary: 31 packages finished [1.50s]
[connext_cmake_module] Warning: The location at which Connext was found when the workspace was built [[/opt/rti.com/rti_connext_dds-5.3.1]] does not point to a valid directory, and the NDDSHOME environment variable has not been set. Support for Connext will not be available.
Starting >>> nav2_gazebo_spawner
]0;colcon build [0/1 done] [1 ongoing]Finished <<< nav2_gazebo_spawner [0.78s]
]0;colcon build [1/1 done] [0 ongoing]
Summary: 1 package finished [1.08s]
CircleCI received exit code 0
```

</details>


## Test Workspace | /opt/overlay_ws 4s

<details>

```
#!/bin/bash -eo pipefail
TEST_FAILURES=$(
  colcon list \
    --names-only \
    --packages-select-test-failures \
  | xargs)
TEST_VOID=$(
  colcon list \
    --names-only \
    --packages-select-cache-void \
    --packages-respective-cache-verb test \
  | xargs)

. install/setup.sh
TEST_PACKAGES=$(
  colcon list \
    --names-only \
    --packages-above \
      $TEST_FAILURES \
      $TEST_VOID \
  | circleci tests split \
    --split-by=timings \
    --timings-type=classname \
    --show-counts \
  | xargs)
set -o xtrace
colcon test \
  --packages-select ${TEST_PACKAGES} \
  --retest-until-pass ${RETEST_UNTIL_PASS} \
  --ctest-args --test-regex "test_.*"
colcon test-result \
  --verbose

[connext_cmake_module] Warning: The location at which Connext was found when the workspace was built [[/opt/rti.com/rti_connext_dds-5.3.1]] does not point to a valid directory, and the NDDSHOME environment variable has not been set. Support for Connext will not be available.
Read 1 lines of classname(s)
Error reading historical timing data: file does not exist
Requested weighting by historical based timing, but they are not present. Falling back to weighting by name.
Bucket 0: assigning 1 classname(s), total weight 1
+ colcon test --packages-select nav2_gazebo_spawner --retest-until-pass 2 --ctest-args --test-regex 'test_.*'
Starting >>> nav2_gazebo_spawner
]0;colcon test [0/1 done] [1 ongoing]Finished <<< nav2_gazebo_spawner [1.01s]
]0;colcon test [1/1 done] [0 ongoing]
Summary: 1 package finished [1.36s]
+ colcon test-result --verbose
Summary: 2274 tests, 0 errors, 0 failures, 0 skipped
CircleCI received exit code 0
```

</details>

cc @SteveMacenski